### PR TITLE
ALOY 1237

### DIFF
--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -353,7 +353,6 @@ exports.generateNode = function(node, state, defaultId, isTopLevel, isModelOrCol
 
 		_.each(args.events, function(ev) {
 			var eventObj = {
-				id: args.id,
 				obj: isModelOrCollection ? state.args.symbol : args.symbol,
 				ev: ev.name,
 				cb: ev.value,
@@ -373,7 +372,7 @@ exports.generateNode = function(node, state, defaultId, isTopLevel, isModelOrCol
 			}
 			var theListener = '';
 			if (eventFunc === 'addEventListener') {
-				theListener = _.template("$.__events.push({id:'<%= id %>',type:'<%= ev %>',handler:<%= cb %>});", eventObj);
+				theListener = _.template("$.trackEvent(<%= obj %>,'<%= ev %>',<%= cb %>);", eventObj);
 			}
 
 			// add the generated code to the view code and post-controller code respectively

--- a/Alloy/commands/compile/compilerUtils.js
+++ b/Alloy/commands/compile/compilerUtils.js
@@ -362,7 +362,7 @@ exports.generateNode = function(node, state, defaultId, isTopLevel, isModelOrCol
 
 			// create templates for immediate and deferred event handler creation
 			var theDefer = _.template("__defers['<%= obj %>!<%= ev %>!<%= escapedCb %>']", eventObj);
-			var theEvent = _.template("<%= obj %>.<%= func %>('<%= ev %>',<%= cb %>)", eventObj);
+			var theEvent = (eventFunc === 'addEventListener') ? _.template("$.addListener(<%= obj %>,'<%= ev %>',<%= cb %>)", eventObj) : _.template("<%= obj %>.<%= func %>('<%= ev %>',<%= cb %>)", eventObj);
 			var deferTemplate = theDefer + " && " + theEvent + ";";
 			var immediateTemplate;
 			if (/[\.\[]/.test(eventObj.cb)) {
@@ -370,15 +370,10 @@ exports.generateNode = function(node, state, defaultId, isTopLevel, isModelOrCol
 			} else {
 				immediateTemplate = "<%= cb %>?" + theEvent + ":" + theDefer + "=true;";
 			}
-			var theListener = '';
-			if (eventFunc === 'addEventListener') {
-				theListener = _.template("$.trackEvent(<%= obj %>,'<%= ev %>',<%= cb %>);", eventObj);
-			}
 
 			// add the generated code to the view code and post-controller code respectively
 			code.content += _.template(immediateTemplate, eventObj);
 			postCode = _.template(deferTemplate, eventObj);
-			postCode +=　theListener;
 			exports.postCode += state.condition ? _.template(codeTemplate, {
 				condition: state.condition,
 				content: postCode

--- a/Alloy/lib/alloy/controllers/BaseController.js
+++ b/Alloy/lib/alloy/controllers/BaseController.js
@@ -24,7 +24,7 @@ var Controller = function() {
 		} : self.__controllerPath;
 	}
 
-	function trackEvent(obj, type, callback) {
+	function trackListener(obj, type, callback) {
 		var id = obj.id || (obj.id = Ti.Platform.createUUID());
 		self.__events.push({id:id,type:type,handler:callback});
 		return id;
@@ -421,7 +421,7 @@ The 'redbg' and 'bigger' classes are shown below:
 		 * @param {Function} callback Callback to receive event.
 		 */
 		addListener: function(obj, type, callback) {
-			var id = trackEvent(obj, type, callback);
+			var id = trackListener(obj, type, callback);
 			obj.addEventListener(type, callback);
 			return id;
 		},

--- a/Alloy/lib/alloy/controllers/BaseController.js
+++ b/Alloy/lib/alloy/controllers/BaseController.js
@@ -24,6 +24,12 @@ var Controller = function() {
 		} : self.__controllerPath;
 	}
 
+	function trackEvent(obj, type, callback) {
+		var id = obj.id || (obj.id = Ti.Platform.createUUID());
+		self.__events.push({id:id,type:type,handler:callback});
+		return id;
+	}
+
 	this.__iamalloy = true;
 	_.extend(this, Backbone.Events, {
 		__views: {},
@@ -402,121 +408,28 @@ The 'redbg' and 'bigger' classes are shown below:
 		},
 
 		/**
-		 * @method getEvent
-		 * Returns the specified events associated with this controller.
-		 *
-		 * If no `id` is specified, returns the first top-level view events.
+		 * @method addListener
+		 * Add a tracked event listeners to a view proxy object.
 		 *
 		 * #### Example
-		 * The following example gets a events to a `<Label/>` object
-		 * with the `id` of "label".
+		 * When is closed window, remove the all events.
 
-	<Alloy>
-		<Window>
-			<Label id="label" onClick="doClick">Hello, world</Label>
-		</Window>
-	</Alloy>		 
+	$.addListener($.aView, 'click', onClick);
 
-		* The following outputs the view-controller id, event type
-		* and event handler of dictionary in array.
-
-	var event = $.getEvent('label');
-	console.log(event);
-
-	[INFO]  (
-	[INFO]      {
-	[INFO]          handler = "<KrollCallback: 0x00000000>";
-	[INFO]          id = label;
-	[INFO]          type = click;
-	[INFO]      }
-	[INFO]  )
-
-		 * @return {Array.<Dictionary>}
+		 * @param {Object} obj Proxy view object to listen to.
+		 * @param {String} type Event type to listen to.
+		 * @param {Function} callback Callback to receive event.
 		 */
-		getEvent: function(id) {
-			if (typeof id === 'undefined' || id === null) {
-				id = roots[0].id;
-			}
-			return _.filter(this.__events, function(event) {
-				return event.id === id;
-			});
+		addListener: function(obj, type, callback) {
+			var id = trackEvent(obj, type, callback);
+			obj.addEventListener(type, callback);
+			return id;
 		},
+
 		/**
-		 * @method getEvents
-		 * Returns the all events associated with this controller.
-		 *
-		 * #### Example
-		 * When is opened window, get the all events.
-
-	<Alloy>
-		<Window id="window" onOpen="doOpen" onClose="doClose">
-			<Label id="label" onClick="doClick">Hello, world</Label>
-		</Window>
-	</Alloy>		 
-
-		* The following outputs the view-controller id, event type
-		* and event handler of dictionary in array.
-
-	function doOpen() {
-		var events = $.getEvents();
-		console.log(event);
-	}
-
-	[INFO]  (
-	[INFO]      {
-	[INFO]          handler = "<KrollCallback: 0x00000000>";
-	[INFO]          id = window;
-	[INFO]          type = open;
-	[INFO]      },
-	[INFO]      {
-	[INFO]          handler = "<KrollCallback: 0x00000001>";
-	[INFO]          id = window;
-	[INFO]          type = close;
-	[INFO]      },
-	[INFO]      {
-	[INFO]          handler = "<KrollCallback: 0x00000002>";
-	[INFO]          id = label;
-	[INFO]          type = click;
-	[INFO]      }
-	[INFO]  )
-
-		 * @return {Array.<Dictionary>}
-		 */
-		getEvents: function() {
-			return this.__events;
-		},
-		/**
-		 * @method removeEvent
-		 * Remove the specified events associated with this controller.
-		 *
-		 * If no `id` is specified, remove the first top-level view events.
-		 *
-		 * #### Example
-		 * The following example remove a events to a `<Label/>` object
-		 * with the `id` of "label".
-
-	<Alloy>
-		<Window>
-			<Label id="label" onClick="doClick">Hello, world</Label>
-		</Window>
-	</Alloy>		 
-
-	$.removeEvent('label');
-		 */
-		removeEvent: function(id) {
-			if (typeof id === 'undefined' || id === null) {
-				id = roots[0].id;
-			}
-			_.each(this.__events, function(event, index) {
-				if (event.id === id) {
-					self.__views[event.id].removeEventListener(event.type, event.handler);
-					delete self.__events[index];
-				}
-			});
-		},
-		/**
-		 * @method removeEvents
-		 * Remove the all events associated with this controller.
+		 * @method removeListener
+		 * Remove the event listeners associated with a combination of
+		 * view proxy object, event type and/or callback.
 		 *
 		 * #### Example
 		 * When is closed window, remove the all events.
@@ -528,14 +441,20 @@ The 'redbg' and 'bigger' classes are shown below:
 	</Alloy>		 
 
 	function doClose() {
-		$.removeEvents();
+		$.removeListener();
 	}
+		 * @param {Object} [obj] Proxy view object to remove from.
+		 * @param {String} [type] Event type to remove.
+		 * @param {Function} [callback] Callback to remove.
 		 */
-		removeEvents: function() {
+		removeListener: function(obj, type, callback) {
 			_.each(this.__events, function(event, index) {
-				self.__views[event.id].removeEventListener(event.type, event.handler);
-				delete self.__events[index];
+				if ((!obj || obj.id === event.id) && (!type || type === event.type) && (!callback || callback === event.handler)) {
+					self.__views[event.id].removeEventListener(event.type, event.handler);
+					delete self.__events[index];
+				}
 			});
+			return this;
 		}
 	});
 };

--- a/test/apps/testing/ALOY-1237/controllers/index.js
+++ b/test/apps/testing/ALOY-1237/controllers/index.js
@@ -1,19 +1,25 @@
 function doOpen() {
+
+  // manually add event
+  $.addListener($.index, 'click', doWindowClick);
+
 	// Showing the all events in this controller
-	var events = $.getEvents();
-	_.each(events, function(event){
+	_.each($.__events, function(event){
 		console.log(event);
 	});
 }
 
-function doClose() {
-	// Window closed event
+// Once event fire, you do not fire again.
+// All events to this window have been removed.
+function doWindowClick() {
+	$.removeListener($.index);
+  console.log('Removed the all events on this window');
 }
 
 // Once event fire, you do not fire again.
 // All events was nothing in this controller.
 function doClick() {
-	$.removeEvents();
+	$.removeListener();
 	console.log('Removed the all events in this controller');
 }
 

--- a/test/apps/testing/ALOY-1237/views/index.xml
+++ b/test/apps/testing/ALOY-1237/views/index.xml
@@ -1,5 +1,5 @@
 <Alloy>
-	<Window onOpen="doOpen" onClose="doClose">
+	<Window onOpen="doOpen">
 		<Label id="label" onClick="doClick">Remove the all events in this controller</Label>
 	</Window>
 </Alloy>


### PR DESCRIPTION
- Add support for manually adding tracked event listeners via `$.addListener($.myView, 'click', doClick);`.
- Remove `$.getEvent/getEvents()` since they have not much value apart from testing.
- Combine `$.removeEvent/removeEvents()` into a single, more versatile `$.removeListener()`.
- Updated testing app.
